### PR TITLE
Align prompt with first line of commands

### DIFF
--- a/css/explaingit.css
+++ b/css/explaingit.css
@@ -168,7 +168,7 @@ span.cmd {
   padding-left: 15px;
   color: #FFF;
   line-height: 14px;
-  background: url(../images/prompt.gif) no-repeat left center black;
+  background: url(../images/prompt.gif) no-repeat left top black;
 }
 
 .control-box input[type="text"] {


### PR DESCRIPTION
When a command is longer than the width of the command box, it gets wrapped, but then the prompt is aligned with the center of the multi-line command. Instead it should be top-aligned to it shows up to the left of the first line of the command, like it would in a terminal.

| Before | After |
| --- | --- |
| <img width="251" alt="screen shot 2016-09-14 at 10 29 34 pm" src="https://cloud.githubusercontent.com/assets/265620/18539446/37089e48-7acc-11e6-90be-35bf6a2fb822.png"> | <img width="251" alt="screen shot 2016-09-14 at 10 27 50 pm" src="https://cloud.githubusercontent.com/assets/265620/18539450/41b7ee16-7acc-11e6-91ac-8aa8b061e70b.png"> |
