### PR TITLE
Added `git push -u ...` handling (noop)

### DIFF
--- a/js/controlbox.js
+++ b/js/controlbox.js
@@ -737,8 +737,8 @@ function(_yargs, d3, demos) {
 
     push: function(args, opts, cmdStr) {
       var opt = yargs(cmdStr, {
-        alias: { force: ['f'] },
-        boolean: ['f']
+        alias: { force: ['f'], upstream: ['u'] },
+        boolean: ['f', 'u']
       })
 
       if (this.mode !== 'local') {


### PR DESCRIPTION
This had been causing an error:

```
$ git push -u origin feature
There is no remote server named "feature".
```