### PR TITLE
Replacing checks for '/' in branch names by checks for "origin/"

### DIFF
--- a/js/historyview.js
+++ b/js/historyview.js
@@ -860,7 +860,7 @@ define(['d3'], function() {
 
       for (b = 0; b < this.branches.length; b++) {
         branch = this.branches[b];
-        if (branch.indexOf('/') === -1) {
+        if (!branch.startsWith("origin/")) {
           commit = this.getCommit(branch);
           parent = this.getCommit(commit.parent);
           parent2 = this.getCommit(commit.parent2);
@@ -916,7 +916,7 @@ define(['d3'], function() {
           var classes = 'branch-tag';
           if (d.name.indexOf('[') === 0 && d.name.indexOf(']') === d.name.length - 1) {
             classes += ' git-tag';
-          } else if (d.name.indexOf('/') >= 0) {
+          } else if (d.name.startsWith("origin/")) {
             classes += ' remote-branch';
           } else if (d.name.toUpperCase() === 'HEAD') {
             classes += ' head-tag';
@@ -963,7 +963,7 @@ define(['d3'], function() {
       var display = this.svg.select('text.current-branch-display'),
         text = 'HEAD: ';
 
-      if (branch && branch.indexOf('/') === -1) {
+      if (branch && !branch.startsWith("origin/")) {
         text += branch;
         this.currentBranch = branch;
       } else {


### PR DESCRIPTION
The problem described in #101 seems to be caused by several locations checking if a branch name contains a forward slash '/' to identify remote branches. However, this over-approximating check makes it impossible to illustrate, e.g., a git flow using branch names like "feature/foobar". 
In my changes I replaced the check for '/' by a check for "origin/", which seems to solve the problem. However, this solution will again fail as soon as a remote is not called origin, so this is also not the best solution.
It can be tested already on the fork: https://johanneslerch.github.io/visualizing-git/