### PR TITLE
Fix typo in cherry-pick

### DIFF
--- a/js/controlbox.js
+++ b/js/controlbox.js
@@ -237,7 +237,7 @@ function(_yargs, d3, demos) {
         this.info('Available Git Commands:')
         this.info('`git branch`')
         this.info('`git checkout`')
-        this.info('`git cherry_pick`')
+        this.info('`git cherry-pick`')
         this.info('`git commit`')
         this.info('`git fetch`')
         this.info('`git log`')


### PR DESCRIPTION
`git cherry_pick` should be `git cherry-pick` in the help output. I'm unsure if https://github.com/git-school/visualizing-git/blob/38ebc468d92a34d72bf9787d4af1b9e208620a01/js/controlbox.js#L412 this function needs to be renamed as well, so I wanted to call it out.

If we do change it, then I think we also need to change the README here: https://github.com/git-school/visualizing-git/blob/38ebc468d92a34d72bf9787d4af1b9e208620a01/README.md#L35 (command list at bottom).