### PR TITLE
Change the term 'master' to 'main'

### DIFF
--- a/examples/merging.md
+++ b/examples/merging.md
@@ -9,9 +9,9 @@ git commit
 git commit
 ```
 
-Merge `feature1` into `master`
+Merge `feature1` into `main`
 ```
-git checkout master
+git checkout main
 git merge feature1 --no-ff
 // --no-ff means "no fast-forward"
 // see below on discussion
@@ -31,23 +31,23 @@ git push
 Typically when we think about a merge, we are combining two branches that both have changes introduced to them:
 ![explain_git_with_d3](https://cloud.githubusercontent.com/assets/7910250/17196198/a5e734ea-5417-11e6-838c-2a030ad0ef70.png)
 
-When we merge feature into master, Git creates a merge commit with two parents (the branch heads).
+When we merge feature into main, Git creates a merge commit with two parents (the branch heads).
 ![explain_git_with_d3](https://cloud.githubusercontent.com/assets/7910250/17196233/f5da5db0-5417-11e6-9d25-34a52603e25f.png)
 
-But let's say we have the two branches in the image below and we want to merge `feature1` into `master`.
+But let's say we have the two branches in the image below and we want to merge `feature1` into `main`.
 
 ![explain_git_with_d3](https://cloud.githubusercontent.com/assets/7910250/17195190/47c33676-5411-11e6-93cb-50f904a14f55.png)
 
-Note that the `master` branch is pointing to a commit that is already in the history of the `feature1` branch. This means that all of the commits on the `master` branch are *already* on the `feature1` branch.
+Note that the `main` branch is pointing to a commit that is already in the history of the `feature1` branch. This means that all of the commits on the `main` branch are *already* on the `feature1` branch.
 
-In this case, when you tell Git to merge, it will do a *fast-forward merge* by default, meaning it will simply move (or *fast-forward*) the `master` and `HEAD` refs so that they point to the commit that `feature1` points to.
+In this case, when you tell Git to merge, it will do a *fast-forward merge* by default, meaning it will simply move (or *fast-forward*) the `main` and `HEAD` refs so that they point to the commit that `feature1` points to.
 
 ![explain_git_with_d3](https://cloud.githubusercontent.com/assets/7910250/17195338/efa3b078-5411-11e6-81dc-6324701433a4.png)
 
 This can be useful because it minimizes branching in our commit history. Remember that `git pull` consists of a `git fetch` then a `git merge`. What if every time we pulled we got a new merge commit instead of doing a *fast-forward* merge. Then we would get meaningless and unnecessary merge commits that would clutter up our history, and `git log` would show a mess of branches.
 
 Sometimes it's useful to show a branch as being a separate section of our history.
-For example, say we've done a bunch of work on a feature branch and want to make it clear which commits were on it after merging into master.
+For example, say we've done a bunch of work on a feature branch and want to make it clear which commits were on it after merging into main.
 
 In this case we want to force Git to create a new merge commit and NOT do a *fast-forward merge* by default by saying `git merge feature1 --no-ff`.
 
@@ -69,7 +69,7 @@ With the merge commits it becomes clear which commits correspond to a given feat
 Have you seen this in your console before?
 ```
 To https://github.com/USERNAME/REPOSITORY.git
- ! [rejected]        master -> master (non-fast-forward)
+ ! [rejected]        main -> main (non-fast-forward)
 error: failed to push some refs to 'https://github.com/USERNAME/REPOSITORY.git'
 To prevent you from losing history, non-fast-forward updates were rejected
 Merge the remote changes (e.g. 'git pull') before pushing again.  See the

--- a/js/demos.js
+++ b/js/demos.js
@@ -5,7 +5,7 @@ define([], function () {
     key: 'free',
     message: 'Have fun!',
     commitData: [
-        {id: 'e137e9b', tags: ['master'], message: 'first commit'},
+        {id: 'e137e9b', tags: ['main'], message: 'first commit'},
     ]
   }
 
@@ -14,10 +14,10 @@ define([], function () {
     key: 'free-remote',
     message: 'Have fun!',
     commitData: [
-        {id: 'e137e9b', tags: ['master', 'origin/master'], message: 'first commit'},
+        {id: 'e137e9b', tags: ['main', 'origin/main'], message: 'first commit'},
     ],
     originData: [
-        {id: 'e137e9b', tags: ['master'], message: 'first commit'}
+        {id: 'e137e9b', tags: ['main'], message: 'first commit'}
     ]
   }
 
@@ -36,7 +36,7 @@ define([], function () {
       {
         "id": "84c98fe",
         "parent": "e137e9b",
-        "tags": [ "master", "origin/master" ],
+        "tags": [ "main", "origin/main" ],
       },
       {
         "id": "1c016b6",
@@ -54,7 +54,7 @@ define([], function () {
       {
         "id": "84c98fe",
         "parent": "e137e9b",
-        "tags": [ "master", "HEAD" ],
+        "tags": [ "main", "HEAD" ],
       },
       {
         "id": "1c016b6",
@@ -88,8 +88,8 @@ define([], function () {
         "id": "84c98fe",
         "parent": "e137e9b",
         "tags": [
-          "master",
-          "origin/master"
+          "main",
+          "origin/main"
         ],
         "cx": 140,
         "cy": 330,
@@ -138,7 +138,7 @@ define([], function () {
         "id": "84c98fe",
         "parent": "e137e9b",
         "tags": [
-          "master"
+          "main"
         ],
         "cx": 140,
         "cy": 360,
@@ -227,7 +227,7 @@ define([], function () {
         "parent2": "077415f",
         "id": "8686fb6",
         "tags": [
-          "master",
+          "main",
           "HEAD"
         ],
         "message": "Merge",
@@ -336,7 +336,7 @@ define([], function () {
         "parent2": "12e9bbb",
         "id": "5749661",
         "tags": [
-          "master"
+          "main"
         ],
         "message": "Merge",
         "parent": "e8ce346",
@@ -352,7 +352,7 @@ define([], function () {
     key: 'rebase',
     message: 'Try rebasing the `feature` branch',
     commitData: [
-        {id: 'e137e9b', tags: ['master'], message: 'first commit'}
+        {id: 'e137e9b', tags: ['main'], message: 'first commit'}
     ]
   }
 

--- a/js/historyview.js
+++ b/js/historyview.js
@@ -255,7 +255,7 @@ define(['d3'], function() {
     this.name = config.name || 'UnnamedHistoryView';
     this.commitData = commitData;
 
-    this.currentBranch = config.currentBranch || 'master';
+    this.currentBranch = config.currentBranch || 'main';
 
     this.width = config.width;
     this.height = config.height || 400;


### PR DESCRIPTION
Change the term 'master' to 'main' as the default name for the main branch.