### PR TITLE
Add support for '-d' and '--delete' in git tag

### DIFF
--- a/js/controlbox.js
+++ b/js/controlbox.js
@@ -506,6 +506,12 @@ function(_yargs, d3, demos) {
 
       while (args.length > 0) {
         var arg = args.shift();
+        
+        if(arg.trim() === '-d' || arg.trim() === '--delete'){
+          var tagName = args.shift();
+          this.getRepoView().deleteTag(tagName);
+          return this;
+        }
 
         try {
           this.getRepoView().tag(arg);

--- a/js/historyview.js
+++ b/js/historyview.js
@@ -1228,6 +1228,16 @@ define(['d3'], function() {
       this.branch('[' + name + ']');
     },
 
+    deleteTag: function(name) {
+      this.branches = this.branches.filter(branch => branch !== `[${name.trim()}]`);
+
+      this.commitData.forEach(commit => {
+        commit.tags = commit.tags.filter(tag => tag !== `[${name.trim()}]`)
+      });
+
+      this.renderTags();
+    },
+
     deleteBranch: function(name) {
       var branchIndex,
         commit;


### PR DESCRIPTION
This commit resolves #116 by adding support for `-d` and `--delete`
in `git tag` command